### PR TITLE
Resolved: Override for babel-plugin-macros@^3.1.0 conflicts error

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "wouter": "2.7.4"
   },
   "overrides": {
-    "babel-plugin-macros": "^3.0.1"
+    "babel-plugin-macros": "^3.1.0"
   },
   "devDependencies": {
     "@types/three": "^0.156.0",


### PR DESCRIPTION
Resolved npm install error:
npm error Override for babel-plugin-macros@^3.1.0 conflicts with direct dependency
npm error A complete log of this run can be found in: /home/toor/.npm/_logs/2024-10-12T23_17_39_661Z-debug-0.log